### PR TITLE
ログイン処理の修正

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -12,25 +12,25 @@ class Users::SessionsController < Devise::SessionsController
 
   # POST /resource/sign_in
   def create
-    # Email空白入力の場合は同ページへリダイレクト
-    if params[:user].blank?
-      flash[:alert] = 'Sorry. But input your Email again'
-      redirect_to new_user_session_path
-    elsif params[:user][:email].blank?
+    if params[:user][:email].blank?
       flash[:alert] = "Email can't be blank"
-      redirect_to new_user_session_path
+      @user = User.new
+      render :new
     else
       # テーブル上の該当ユーザーの有無で分岐
       user = User.find_by(email: params[:user][:email])
+      email = params[:user][:email]
       if user.nil?
         flash[:alert] = "Your account could't find"
+        @user = User.new(email: email)
         render :new
       elsif user.valid_password?(params[:user][:password]) && user.deleted_at.nil?
         # 過去に削除されたアカウントの場合か否かで分岐
         sign_in user
-        redirect_to root_path
+        redirect_back(fallback_location: root_path)
       else
-        flash[:alert] = 'Failed to log-in.'
+        flash[:alert] = 'Failed to log-in. Check your password, please'
+        @user = User.new(email: email)
         render :new
       end
     end


### PR DESCRIPTION
# what
- ログイン処理の修正

# why
- ログイン失敗時の挙動が不安定だったため

### contents
- redirect_to　で対応していた処理を、再度@userインスタンスを渡した状態でrenderに変更
- 余分な条件分岐を削減
- ログイン成功時のリダイレクト先を元のページへ変更